### PR TITLE
Updates to support iOS 6

### DIFF
--- a/openssl.xcodeproj/project.pbxproj
+++ b/openssl.xcodeproj/project.pbxproj
@@ -92,8 +92,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphoneos*]" = (
-					armv6,
 					armv7,
+					armv7s,
 				);
 				"ARCHS[sdk=macosx*]" = (
 					x86_64,
@@ -111,8 +111,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphoneos*]" = (
-					armv6,
 					armv7,
+					armv7s,
 				);
 				"ARCHS[sdk=macosx*]" = (
 					x86_64,


### PR DESCRIPTION
Note: This binary will _not_ be able to be rebuilt from source with Xcode versions less than 4.5, as the valid architectures had to be hard-coded, since there's no iOS-specific macro when you're also supporting Max OS X versions in your build, which this does.

The existing binary distribution should work fine with older versions of Xcode, though, and this package does not get rebuilt without explicit actions from the user.
